### PR TITLE
Added the code generator for MPDE

### DIFF
--- a/components/dsls/vector-test/test/mpde/vector/test/CodeGenSpec.scala
+++ b/components/dsls/vector-test/test/mpde/vector/test/CodeGenSpec.scala
@@ -1,0 +1,37 @@
+package mpde.vector.test
+
+import org.scalatest._
+import dsl.print._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class CodeGenSpec extends FlatSpec with ShouldMatchers {
+
+  "Static code staging" should "work" in {
+    safe_println("Please ignore the following output (should print 7):")
+
+    assert(liftPrint {
+      val x = 1
+      val y = 2
+      val z = 4
+      println(x + y + z)
+      returns(x + y + z)
+    } == 7) // should print "7" and return "7"
+  }
+
+  "Dynamic code insertion" should "work" in {
+
+    safe_println("Please ignore the following output (should print 7, again):")
+
+    val x = 1
+    val y = 2
+
+    assert(
+      liftPrint {
+        val z = 4
+        println(x + y + z)
+        returns(x + y + z)
+      } == 7) // should print "7" and return "7"
+  }
+}

--- a/components/dsls/vector-test/test/mpde/vector/test/PrototypeSpec.scala
+++ b/components/dsls/vector-test/test/mpde/vector/test/PrototypeSpec.scala
@@ -107,7 +107,7 @@ class PrototypeSpec extends FlatSpec with ShouldMatchers {
       //          DenseVector(liftTerm(1)).map(x => x + 1)
       //        }
       //      }
-      //            dsl.la.DenseVector(1,2,3).map(x => x + 1)      
+      //            dsl.la.DenseVector(1,2,3).map(x => x + 1)
     }
     ()
   }

--- a/components/dsls/vector/src/base/Interpret.scala
+++ b/components/dsls/vector/src/base/Interpret.scala
@@ -2,12 +2,6 @@ package base
 
 trait Interpret {
 
-  def main()
-
-  def interpret() = {
-    val res = main()
-    // return a regular scala type (Unit for now)
-    ()
-  }
-
+  def main(): Any
+  def interpret(): Any = main()
 }

--- a/components/dsls/vector/src/dsl/la/norep/VectorOpsNoReps.scala
+++ b/components/dsls/vector/src/dsl/la/norep/VectorOpsNoReps.scala
@@ -11,6 +11,7 @@ trait IntDSL extends Base {
   type Int = IntOps
 
   //TODO (TOASK) where do we provide the implementation for this methods (in result DSL object)
+  // v: When we stage, we should have the provide the implementation that actually lifts the entire thing
   trait IntOps {
     def +(that: Int): Int
     def +(that: Double): Double
@@ -26,8 +27,9 @@ trait IntDSL extends Base {
   }
 
   //TODO (TOASK) why do we need to provide implementation for this method
+  // v: Else Scala won't let you declare the object with abstract methods
   implicit object LiftInt extends LiftEvidence[scala.Int, Int] {
-    def lift(v: scala.Int): Int = null
+    def lift(v: scala.Int): Int = null // TODO: Wouldn't this better be a ???
   }
 
   implicit object LiftUnit extends LiftEvidence[scala.Unit, Unit] {

--- a/components/dsls/vector/src/dsl/la/package.scala
+++ b/components/dsls/vector/src/dsl/la/package.scala
@@ -7,12 +7,11 @@ import scala.reflect.macros.Context
 package object la {
 
   // TODO should not return Unit but a value
-  def laLift[T](block: ⇒ T): Unit = macro lift[T]
+  def laLift[T](block: ⇒ T): Unit = macro implementations.lift[T]
+  def laDebug[T](block: ⇒ T): Unit = macro implementations.liftDebug[T]
 
-  def laDebug[T](block: ⇒ T): Unit = macro liftDebug[T]
-
-  def lift[T](c: Context)(block: c.Expr[T]): c.Expr[T] = new MPDETransformer[c.type, T](c, "VectorDSL")(block)
-
-  def liftDebug[T](c: Context)(block: c.Expr[T]): c.Expr[T] = new MPDETransformer[c.type, T](c, "VectorDSL", debug = true)(block)
-
+  object implementations {
+    def lift[T](c: Context)(block: c.Expr[T]): c.Expr[T] = new MPDETransformer[c.type, T](c, "VectorDSL")(block)
+    def liftDebug[T](c: Context)(block: c.Expr[T]): c.Expr[T] = new MPDETransformer[c.type, T](c, "VectorDSL", debug = true)(block)
+  }
 }

--- a/components/dsls/vector/src/dsl/print/LiftedPrint.scala
+++ b/components/dsls/vector/src/dsl/print/LiftedPrint.scala
@@ -1,0 +1,63 @@
+package dsl.print
+
+/** The int printing DSL */
+trait PrintDSLStage extends base.LiftBase with MiniIntDSL with MiniUnitDSL with MiniPrintDSL with base.Interpret {
+
+  var sb: StringBuffer = new StringBuffer()
+
+  // hey, we can refine println -- but we don't need it right now
+  def println(x: Any) = sb.append(s"scala.Predef.println(${x.toString});\n")
+  def returns(x: Any) = sb.append(x.toString + ";\n") // added because we cannot test output
+
+  override def interpret(): Any = {
+    this.main()
+    sb.toString
+  }
+}
+
+trait PrintDSLInterpret extends base.LiftBase with MiniUnitDSL with MiniPrintDSL with base.Interpret {
+
+  type Int = scala.Int
+  implicit object LiftInt extends LiftEvidence[scala.Int, scala.Int] { def lift(i: Int) = i }
+
+  // hey, we can refine println -- but we don't need it right now
+  def println(x: Any) = scala.Predef.println(x.toString)
+  def returns(x: Any) = x
+
+  override def interpret(): Any = {
+    this.main()
+  }
+}
+
+trait MiniIntDSL extends base.LiftBase {
+
+  type Int = IntOps
+
+  trait IntOps {
+    def +(that: Int): Int = (IntOps.this, that) match {
+      case (IntConst(x), IntConst(y)) ⇒
+        IntConst(x + y)
+      case _ ⇒
+        IntPlus(IntOps.this, that)
+    }
+  }
+
+  // actual classes that provide lifting
+  case class IntConst(i: scala.Int) extends IntOps { override def toString = s"$i" }
+  case class IntPlus(l: IntOps, r: IntOps) extends IntOps { override def toString = s"$l + $r" }
+
+  implicit object LiftInt extends LiftEvidence[scala.Int, Int] {
+    def lift(v: scala.Int): Int = IntConst(v)
+  }
+}
+
+trait MiniUnitDSL extends base.LiftBase {
+  implicit object LiftUnit extends LiftEvidence[scala.Unit, Unit] {
+    def lift(v: Unit): Unit = ()
+  }
+}
+
+trait MiniPrintDSL extends base.LiftBase {
+  def println(x: Any): Unit
+  def returns(x: Any): Any
+}

--- a/components/dsls/vector/src/dsl/print/package.scala
+++ b/components/dsls/vector/src/dsl/print/package.scala
@@ -1,0 +1,61 @@
+package dsl.print
+
+import ch.epfl.lamp.mpde._
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+import scala.tools.reflect.ToolBoxFactory
+
+object `package` {
+
+  // Debugging aids
+  private[this] final val DEBUG_PRINT_DSL = false
+
+  def liftPrint[T](block: ⇒ T): Any = macro _liftPrint[T]
+  def _liftPrint[T](c: Context)(block: c.Expr[T]): c.Expr[T] = {
+    import c._
+    import c.universe._
+
+    def safe_println(x: Any) = if (DEBUG_PRINT_DSL) scala.Predef.println(x) else ()
+
+    safe_println("********************************************************************************")
+    safe_println("Lifting:")
+    safe_println(block)
+
+    // Staging workflow:
+    //
+    //  program code (block) ==> lifted code ==> staged code ==> parsed trees
+    //
+    // if there are external dependencies, like in:
+    //
+    // val x = 3
+    // liftPrint { print(x + 4) }
+    //
+    // the code can't be evaluated and thus we can only place the lifted code
+    // back in the program and expect to perform interpretation at runtime
+    try {
+      val lifted = new MPDETransformer[c.type, T](c, "dsl.print.PrintDSLStage")(block)
+      val staged = c.eval(lifted).asInstanceOf[String] // we know it returns a string, this is how we defined interpret
+      val parsed = c.parse(staged)
+      safe_println("Static staging (no external dependencies):")
+      safe_println(parsed)
+      safe_println("********************************************************************************")
+      c.Expr(parsed)
+    } catch {
+      case e: scala.tools.reflect.ToolBoxError ⇒
+        safe_println("\nCode has external dependencies:")
+        safe_println(e.getStackTrace.mkString("  ", "\n  ", "\n"))
+        val lifted = new MPDETransformer[c.type, T](c, "dsl.print.PrintDSLInterpret")(block)
+        safe_println("\nWill use interpretation (since code block HAS external dependencies):")
+        safe_println(lifted)
+        safe_println("********************************************************************************")
+        lifted
+    }
+  }
+
+  // The only thing we declare here
+  def println(x: Any) = ???
+  def returns(x: Any) = ??? // added because we cannot test output
+
+  // Still, we need to be able to print:
+  def safe_println(x: Any) = scala.Predef.println(x)
+}


### PR DESCRIPTION
And as a bonus, a small DSL for integer addition, printing and returning.

Quoting from `dsls/vector/src/dsl/print/package.scala`:

```
// Staging workflow:
//
//     program code (block) ==> lifted code ==> staged code ==> parsed trees
//
// if there are external dependencies, like in:
//
// val x = 3
// liftPrint { print(x + 4) }
//
// the code can't be evaluated and thus we can only place the lifted code
// back in the program and expect to perform interpretation at runtime*
```

*putting the lifted code back can be done after partial evaluation
