### PR TITLE
fix requiredHoles to return symbols directly

### DIFF
--- a/components/dsls/vector/src/dsl/la/norep/VectorOpsNoReps.scala
+++ b/components/dsls/vector/src/dsl/la/norep/VectorOpsNoReps.scala
@@ -228,7 +228,7 @@ trait VectorDSL
   with Interpreted {
   type Vector[T] = VectorOps[T]
 
-  def requiredHoles(symbols: List[Symbol]): List[scala.Int] = Nil
+  def requiredHoles(symbols: List[Symbol]): List[Symbol] = Nil
 
   //TODO (NEW) (TOASK) - where should we provide implementation for methods of VectorOps
   trait VectorOps[T] {

--- a/components/framework/src/ch/epfl/yinyang/YYTransformer.scala
+++ b/components/framework/src/ch/epfl/yinyang/YYTransformer.scala
@@ -109,7 +109,7 @@ abstract class YYTransformer[C <: Context, T](val c: C, dslName: String, val con
           }
         }
         case tpe =>
-          reflInstance[BaseYinYang](unboundDSL).requiredHoles(allCaptured.asInstanceOf[List[reflect.runtime.universe.Symbol]]).map(symbolById)
+          reflInstance[BaseYinYang](unboundDSL).requiredHoles(allCaptured.asInstanceOf[List[reflect.runtime.universe.Symbol]]).asInstanceOf[List[Symbol]]
       }
 
       val holes = allCaptured diff reqVars

--- a/components/framework/src/ch/epfl/yinyang/api/BaseYinYang.scala
+++ b/components/framework/src/ch/epfl/yinyang/api/BaseYinYang.scala
@@ -3,14 +3,14 @@ package ch.epfl.yinyang.api
 import reflect.runtime.universe._
 
 trait BaseYinYang {
-
   /**
-   * Returns a list of holes required for run-time optimizations.
+   * Returns the holes required for run-time optimizations.
    * Compile-time optimized DSLs should return `Nil`.
-   *   @return list of holes required for run-time optimizations. Holes will be promoted
-   *           into constants in the next stage of compilation (at runtime).
+   *   @param symbols Maps from hole ids to symbols.
+   *   @return list of hole symbols required for run-time optimizations. Holes will be promoted
+   *           to constants in the next stage of compilation (at runtime).
    */
-  def requiredHoles(symbols: List[Symbol]): List[Int]
+  def requiredHoles(symbols: List[Symbol]): List[Symbol]
 
   /**
    * Abstract super class for implicit lifters that the DSL author needs to provide.

--- a/components/framework/src/ch/epfl/yinyang/api/FullyStaged.scala
+++ b/components/framework/src/ch/epfl/yinyang/api/FullyStaged.scala
@@ -9,7 +9,7 @@ import reflect.runtime.universe.Symbol
  */
 trait FullyStaged { this: BaseYinYang =>
 
-  override def requiredHoles(symbols: List[Symbol]): List[Int] =
+  override def requiredHoles(symbols: List[Symbol]): List[Symbol] =
     throw new RuntimeException("This method must not be called!!!")
 
 }


### PR DESCRIPTION
Commit https://github.com/vjovanov/mpde/commit/5562a5af3156ac7ce88c4f53b6f226987f7247c5 introduced sorted symbols in the YYTransformer, so requiredHoles was expected to return symbol ids instead of hole ids as before. However, because of reflection the symbol ids weren't accessible in the dsl even though a list of symbols was provided to requiredHoles. With this commit, requiredHoles returns the symbols directly, using the hole ids as index into the provided list of hole symbols. The ugly type casting is done by the YYTransformer.
